### PR TITLE
Add --no-nix-pure to `stack script` options in sha256map.hs

### DIFF
--- a/project-nix/sha256map.hs
+++ b/project-nix/sha256map.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack script --resolver=lts-18.27 --package=aeson --package=base --package=dhall --package=text --package=turtle --package=utf8-string
+-- stack script --no-nix-pure --resolver=lts-18.27 --package=aeson --package=base --package=dhall --package=text --package=turtle --package=utf8-string
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
This enables the script to use the `nix-prefetch-git` executable from the calling environment, which it finds using `PATH`, on systems that have nix enabled in the global stack config (eg on NixOS)