### PR TITLE
Reuse intros and drop empty dependency sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   for Cabal.
 * The grammar of the comment describing source package dependencies and forks is
   better, no longer saying 1 packages.
+* With `dhall2cabal` or `dhall2stack` generated projects, source dependencies
+  and their commentary are only included if there are dependencies in a
+  category; internal or external, dependency or fork.
 
 ### 1.0.0
 * First release

--- a/text-templates/dhall2cabal.dhall
+++ b/text-templates/dhall2cabal.dhall
@@ -1,8 +1,8 @@
 let TYPES = ../types.dhall
 
-let length = https://prelude.dhall-lang.org/List/length
+let L = https://prelude.dhall-lang.org/List/package.dhall
 
-let show = https://prelude.dhall-lang.org/Natural/show
+let N = https://prelude.dhall-lang.org/Natural/package.dhall
 
 let concatMapSep = https://prelude.dhall-lang.org/Text/concatMapSep
 
@@ -35,9 +35,9 @@ in  \(stackage-location : TYPES.Stackage) ->
             deps-external # deps-internal # forks-external # forks-internal
 
       let count =
-            \(xs : List TYPES.SourceRepoPkg) -> length TYPES.SourceRepoPkg xs
+            \(xs : List TYPES.SourceRepoPkg) -> L.length TYPES.SourceRepoPkg xs
 
-      let countPkgs = \(xs : List Text) -> show (length Text xs)
+      let countPkgs = \(xs : List Text) -> N.show (L.length Text xs)
 
       let pkgs =
             merge
@@ -63,36 +63,61 @@ in  \(stackage-location : TYPES.Stackage) ->
 
       let comment = concatMapSep "\n" Text (\(s : Text) -> "-- ${s}")
 
-      let deps-count-comment =
-            comment
-              ( counts
-                  { deps-external = count deps-external
-                  , deps-internal = count deps-internal
-                  , forks-external = count forks-external
-                  , forks-internal = count forks-internal
-                  }
+      let dep-counts =
+            { deps-external = count deps-external
+            , deps-internal = count deps-internal
+            , forks-external = count forks-external
+            , forks-internal = count forks-internal
+            }
+
+      let deps-count-comment = comment (counts dep-counts)
+
+      in      ''
+              ${./import-stackage.dhall stackage-location stackage-resolver}
+
+              ${pkgs-comment}
+              ${cabal.packages pkgs}''
+          ++  ( if    L.null TYPES.SourceRepoPkg source-deps
+                then  ""
+                else      ''
+
+                          ${deps-count-comment}''
+                      ++  ( if    N.isZero dep-counts.deps-external
+                            then  ""
+                            else  ''
+
+
+                                  ${comment intros.deps-external}
+                                  ${cabal.repo-items deps-external}''
+                          )
+                      ++  ( if    N.isZero dep-counts.deps-internal
+                            then  ""
+                            else  ''
+
+
+                                  ${comment intros.deps-internal}
+                                  ${cabal.repo-items deps-internal}''
+                          )
+                      ++  ( if    N.isZero dep-counts.forks-external
+                            then  ""
+                            else  ''
+
+
+                                  ${comment intros.forks-external}
+                                  ${cabal.repo-items forks-external}''
+                          )
+                      ++  ( if    N.isZero dep-counts.forks-internal
+                            then  ""
+                            else  ''
+
+
+                                  ${comment intros.forks-internal}
+                                  ${cabal.repo-items forks-internal}''
+                          )
               )
+          ++  ''
 
-      in  ''
-          ${./import-stackage.dhall stackage-location stackage-resolver}
 
-          ${pkgs-comment}
-          ${cabal.packages pkgs}
-
-          ${deps-count-comment}
-
-          ${comment intros.deps-external}
-          ${cabal.repo-items deps-external}
-
-          ${comment intros.deps-internal}
-          ${cabal.repo-items deps-internal}
-
-          ${comment intros.forks-external}
-          ${cabal.repo-items forks-external}
-
-          ${comment intros.forks-internal}
-          ${cabal.repo-items forks-internal}
-
-          -- Constraints are equivalent to stack package-version extra dependencies.
-          ${cabal.constraints pkg-config.constraints}
-          ''
+              -- Version equality constraints.
+              ${cabal.constraints pkg-config.constraints}
+              ''

--- a/text-templates/dhall2cabal.dhall
+++ b/text-templates/dhall2cabal.dhall
@@ -8,6 +8,8 @@ let concatMapSep = https://prelude.dhall-lang.org/Text/concatMapSep
 
 let counts = ./internal/comments/counts.dhall
 
+let intros = ./internal/comments/intros.dhall
+
 in  \(stackage-location : TYPES.Stackage) ->
     \(stackage-resolver : Text) ->
     \(pkg-set : TYPES.PkgSet) ->
@@ -59,11 +61,10 @@ in  \(stackage-location : TYPES.Stackage) ->
 
       let cabal = ./cabal/package.dhall
 
+      let comment = concatMapSep "\n" Text (\(s : Text) -> "-- ${s}")
+
       let deps-count-comment =
-            concatMapSep
-              "\n"
-              Text
-              (\(s : Text) -> "-- ${s}")
+            comment
               ( counts
                   { deps-external = count deps-external
                   , deps-internal = count deps-internal
@@ -79,18 +80,17 @@ in  \(stackage-location : TYPES.Stackage) ->
           ${cabal.packages pkgs}
 
           ${deps-count-comment}
-          -- Source Packages, external (3rd party).
+
+          ${comment intros.deps-external}
           ${cabal.repo-items deps-external}
 
-          -- Source Packages, internal to this organisation (private and public).
+          ${comment intros.deps-internal}
           ${cabal.repo-items deps-internal}
 
-          -- Source Packages, external (3rd party) forks of other repositories.
-          -- Can we help upstream?
+          ${comment intros.forks-external}
           ${cabal.repo-items forks-external}
 
-          -- Source Packages, internal forks of other repositories.
-          -- Can we upstream and unfork?
+          ${comment intros.forks-internal}
           ${cabal.repo-items forks-internal}
 
           -- Constraints are equivalent to stack package-version extra dependencies.

--- a/text-templates/dhall2stack.dhall
+++ b/text-templates/dhall2stack.dhall
@@ -8,6 +8,8 @@ let concatMapSep = https://prelude.dhall-lang.org/Text/concatMapSep
 
 let counts = ./internal/comments/counts.dhall
 
+let intros = ./internal/comments/intros.dhall
+
 in  \(stackage-resolver : Text) ->
     \(pkg-set : TYPES.PkgSet) ->
     \ ( pkg-config
@@ -57,11 +59,10 @@ in  \(stackage-resolver : Text) ->
 
       let stack = ./stack/package.dhall
 
+      let comment = concatMapSep "\n" Text (\(s : Text) -> "# ${s}")
+
       let deps-count-comment =
-            concatMapSep
-              "\n"
-              Text
-              (\(s : Text) -> "# ${s}")
+            comment
               ( counts
                   { deps-external = count deps-external
                   , deps-internal = count deps-internal
@@ -83,15 +84,13 @@ in  \(stackage-resolver : Text) ->
                 else  ''
                       extra-deps:
 
-                        # Source Packages, external (3rd party).
+                      ${comment intros.deps-external}
                       ${stack.repo-items deps-external}
-                        # Source Packages, internal to this organisation (private and public).
+                      ${comment intros.deps-internal}
                       ${stack.repo-items deps-internal}
-                        # Source Packages, external (3rd party) forks of other repositories.
-                        # Can we help upstream?
+                      ${comment intros.forks-external}
                       ${stack.repo-items forks-external}
-                        # Source Packages, internal forks of other repositories.
-                        # Can we upstream and unfork?
+                      ${comment intros.forks-internal}
                       ${stack.repo-items forks-internal}
                         # Package versions for published packages either not on Stackage or
                         # not matching the version on Stackage for the resolver we use.

--- a/text-templates/dhall2stack.dhall
+++ b/text-templates/dhall2stack.dhall
@@ -2,7 +2,7 @@ let TYPES = ../types.dhall
 
 let L = https://prelude.dhall-lang.org/List/package.dhall
 
-let show = https://prelude.dhall-lang.org/Natural/show
+let N = https://prelude.dhall-lang.org/Natural/package.dhall
 
 let concatMapSep = https://prelude.dhall-lang.org/Text/concatMapSep
 
@@ -36,7 +36,7 @@ in  \(stackage-resolver : Text) ->
       let count =
             \(xs : List TYPES.SourceRepoPkg) -> L.length TYPES.SourceRepoPkg xs
 
-      let countPkgs = \(xs : List Text) -> show (L.length Text xs)
+      let countPkgs = \(xs : List Text) -> N.show (L.length Text xs)
 
       let pkgs =
             merge
@@ -60,16 +60,16 @@ in  \(stackage-resolver : Text) ->
       let stack = ./stack/package.dhall
 
       let comment = concatMapSep "\n" Text (\(s : Text) -> "# ${s}")
+      let nested-comment = concatMapSep "\n" Text (\(s : Text) -> "  # ${s}")
 
-      let deps-count-comment =
-            comment
-              ( counts
-                  { deps-external = count deps-external
-                  , deps-internal = count deps-internal
-                  , forks-external = count forks-external
-                  , forks-internal = count forks-internal
-                  }
-              )
+      let dep-counts =
+              { deps-external = count deps-external
+              , deps-internal = count deps-internal
+              , forks-external = count forks-external
+              , forks-internal = count forks-internal
+              }
+
+      let deps-count-comment = comment (counts dep-counts)
 
       in      ''
               resolver: ${stackage-resolver}
@@ -81,19 +81,39 @@ in  \(stackage-resolver : Text) ->
           ++  ( if        L.null TYPES.SourceRepoPkg source-deps
                       &&  L.null TYPES.PkgVer pkg-config.constraints
                 then  "extra-deps: []"
-                else  ''
-                      extra-deps:
+                else      "extra-deps:\n"
+                      ++  ( if    N.isZero dep-counts.deps-external
+                            then  ""
+                            else  ''
 
-                      ${comment intros.deps-external}
-                      ${stack.repo-items deps-external}
-                      ${comment intros.deps-internal}
-                      ${stack.repo-items deps-internal}
-                      ${comment intros.forks-external}
-                      ${stack.repo-items forks-external}
-                      ${comment intros.forks-internal}
-                      ${stack.repo-items forks-internal}
-                        # Package versions for published packages either not on Stackage or
-                        # not matching the version on Stackage for the resolver we use.
-                        # These package-version extra dependencies are equivalent to cabal constraints.
-                      ${stack.constraints pkg-config.constraints}''
+                                  ${nested-comment intros.deps-external}
+                                  ${stack.repo-items deps-external}''
+                          )
+                      ++  ( if    N.isZero dep-counts.deps-internal
+                            then  ""
+                            else  ''
+
+                                  ${nested-comment intros.deps-internal}
+                                  ${stack.repo-items deps-internal}''
+                          )
+                      ++  ( if    N.isZero dep-counts.forks-external
+                            then  ""
+                            else  ''
+
+                                  ${nested-comment intros.forks-external}
+                                  ${stack.repo-items forks-external}''
+                          )
+                      ++  ( if    N.isZero dep-counts.forks-internal
+                            then  ""
+                            else  ''
+
+                                  ${nested-comment intros.forks-internal}
+                                  ${stack.repo-items forks-internal}''
+                          )
+                      ++  ''
+
+                            # Package versions for published packages either not on Stackage or
+                            # not matching the version on Stackage for the resolver we use.
+                            # These package-version extra dependencies are equivalent to cabal constraints.
+                          ${stack.constraints pkg-config.constraints}''
               )

--- a/text-templates/internal/comments/intros.dhall
+++ b/text-templates/internal/comments/intros.dhall
@@ -1,0 +1,12 @@
+{ deps-external = [ "Source Packages, external (3rd party)." ]
+, deps-internal =
+  [ "Source Packages, internal to this organisation (private and public)." ]
+, forks-external =
+  [ "Source Packages, external (3rd party) forks of other repositories."
+  , "Can we help upstream?"
+  ]
+, forks-internal =
+  [ "Source Packages, internal forks of other repositories."
+  , "Can we upstream and unfork?"
+  ]
+}

--- a/types.dhall
+++ b/types.dhall
@@ -5,4 +5,5 @@
 , CabalRelativity = ./types/CabalRelativity.dhall
 , Stackage = ./types/Stackage.dhall
 , DepCounts = ./types/DepCounts.dhall
+, DepIntros = ./types/DepIntros.dhall
 }

--- a/types/DepIntros.dhall
+++ b/types/DepIntros.dhall
@@ -1,0 +1,5 @@
+{ deps-external : List Text
+, deps-internal : List Text
+, forks-external : List Text
+, forks-internal : List Text
+}


### PR DESCRIPTION
Fixes #23 and also doesn't include introduction commentary for a category of source dependency that is empty.