### PR TITLE
Trace the commit url

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,27 +356,35 @@ Dhall is a prerequisite. Updo can bootstrap itself as a makefile recipe in
 ## Bootstrap from Hackage
 
 ```make
+# include bootstrap/hackage.mk
 UPDO_VERSION ?= 1.0.0
-HACKAGE := http://hackage.haskell.org/package
-UPDO_URL := ${HACKAGE}/updo-${UPDO_VERSION}/updo-${UPDO_VERSION}.tar.gz
+UPDO_REPO_ROOT := http://hackage.haskell.org/package
+UPDO_ARCHIVE := ${UPDO_REPO_ROOT}/updo-${UPDO_VERSION}/updo-${UPDO_VERSION}.tar.gz
+UPDO_REF := ${UPDO_REPO_ROOT}/updo-${UPDO_VERSION}
 ```
 
 1. When opting for the scripts:
 
 ```make
+# include bootstrap/bootstrap.mk
 updo/Makefile:
+⇥ (info Referencing Updo at $(UPDO_HACKAGE_URL))
 ⇥ rm -rf updo
-⇥ curl -sSL ${UPDO_URL} | tar -xz
+⇥ curl -sSL ${UPDO_ARCHIVE} | tar -xz
 ⇥ mv updo-* updo
 ⇥ chmod +x $$(grep -RIl '^#!' updo)
 ```
+
+The above as a script is
+[project-bootstrap-hackage.sh](project-bootstrap-hackage.sh).
 
 2. When opting to install the included executables:
 
 ```make
 updo/Makefile:
+⇥ (info Referencing Updo at $(UPDO_HACKAGE_URL))
 ⇥ rm -rf updo
-⇥ curl -sSL ${UPDO_URL} | tar -xz
+⇥ curl -sSL ${UPDO_ARCHIVE} | tar -xz
 ⇥ cd updo-${UPDO_VERSION}
 ⇥ stack install
 ⇥ cd -
@@ -393,15 +401,24 @@ Updo can bootstrap itself from a revision or branch too.
 1. From a revision:
 
 ```make
-UPDO_VERSION ?= 4a8359f4e5d8cad61f35bea9d0a8f04477829ca1
-UPDO_URL := https://github.com/cabalism/updo/archive/${UPDO_VERSION}.tar.gz
+# include bootstrap/repo-archive.mk
+UPDO_COMMIT_HASH ?= 60545b108b7a6a2f802ec7a161aa4b9eb7441baf
+UPDO_REPO_ROOT := https://github.com/cabalism/updo
+UPDO_ARCHIVE := ${UPDO_REPO_ROOT}/archive/${UPDO_COMMIT_HASH}.tar.gz
+UPDO_REF := ${UPDO_REPO_ROOT}/commit/${UPDO_COMMIT_HASH}
+```
 
+```make
+# include bootstrap/bootstrap.mk
 updo/Makefile:
+⇥ (info Referencing Updo at $(UPDO_COMMIT_URL))
 ⇥ rm -rf updo
-⇥ curl -sSL ${UPDO_URL} | tar -xz
+⇥ curl -sSL ${UPDO_ARCHIVE} | tar -xz
 ⇥ mv updo-* updo
 ⇥ chmod +x $$(grep -RIl '^#!' updo)
 ```
+
+The above as a script is [project-bootstrap-repo.sh](project-bootstrap-repo.sh).
 
 2. From a branch:
 

--- a/bootstrap/bootstrap.mk
+++ b/bootstrap/bootstrap.mk
@@ -1,0 +1,6 @@
+updo/Makefile:
+	$(info Referencing Updo at $(UPDO_REF))
+	rm -rf updo
+	curl -sSL ${UPDO_ARCHIVE} | tar -xz
+	mv updo-* updo
+	chmod +x $$(grep -RIl '^#!' updo)

--- a/bootstrap/hackage.mk
+++ b/bootstrap/hackage.mk
@@ -1,0 +1,4 @@
+UPDO_VERSION ?= 1.0.0
+UPDO_REPO_ROOT := http://hackage.haskell.org/package
+UPDO_ARCHIVE := ${UPDO_REPO_ROOT}/updo-${UPDO_VERSION}/updo-${UPDO_VERSION}.tar.gz
+UPDO_REF := ${UPDO_REPO_ROOT}/updo-${UPDO_VERSION}

--- a/bootstrap/repo-archive.mk
+++ b/bootstrap/repo-archive.mk
@@ -1,0 +1,4 @@
+UPDO_COMMIT_HASH ?= 60545b108b7a6a2f802ec7a161aa4b9eb7441baf
+UPDO_REPO_ROOT := https://github.com/cabalism/updo
+UPDO_ARCHIVE := ${UPDO_REPO_ROOT}/archive/${UPDO_COMMIT_HASH}.tar.gz
+UPDO_REF := ${UPDO_REPO_ROOT}/commit/${UPDO_COMMIT_HASH}

--- a/project-bootstrap-hackage.sh
+++ b/project-bootstrap-hackage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+curl \
+  -H 'Accept: application/vnd.github.v3.raw' \
+  -sL https://raw.githubusercontent.com/cabalism/updo/refs/heads/trace/commit-url/bootstrap/hackage.mk \
+  > project-bootstrap.mk
+
+curl \
+  -H 'Accept: application/vnd.github.v3.raw' \
+  -sL https://raw.githubusercontent.com/cabalism/updo/refs/heads/trace/commit-url/bootstrap/bootstrap.mk \
+  >> project-bootstrap.mk

--- a/project-bootstrap-repo.sh
+++ b/project-bootstrap-repo.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+curl \
+  -H 'Accept: application/vnd.github.v3.raw' \
+  -sL https://raw.githubusercontent.com/cabalism/updo/refs/heads/trace/commit-url/bootstrap/repo-archive.mk \
+  > project-bootstrap.mk
+
+curl \
+  -H 'Accept: application/vnd.github.v3.raw' \
+  -sL https://raw.githubusercontent.com/cabalism/updo/refs/heads/trace/commit-url/bootstrap/bootstrap.mk \
+  >> project-bootstrap.mk


### PR DESCRIPTION
Fixes #47.

* Tracing Updo from hackage

```
make -f project-bootstrap.mk
Referencing Updo at http://hackage.haskell.org/package/updo-1.0.0
rm -rf updo
curl -sSL http://hackage.haskell.org/package/updo-1.0.0/updo-1.0.0.tar.gz | tar -xz
mv updo-* updo
chmod +x $(grep -RIl '^#!' updo)
```

* Tracing Updo when referenced as a commit

```
$ make -f project-bootstrap.mk
Referencing Updo at https://github.com/cabalism/updo/commit/60545b108b7a6a2f802ec7a161aa4b9eb7441baf
rm -rf updo
curl -sSL https://github.com/cabalism/updo/archive/60545b108b7a6a2f802ec7a161aa4b9eb7441baf.tar.gz | tar -xz
mv updo-* updo
chmod +x $(grep -RIl '^#!' updo)
```